### PR TITLE
fix broken build on curl > 7.62.0

### DIFF
--- a/smtp/smtpc.c
+++ b/smtp/smtpc.c
@@ -243,7 +243,9 @@ smtpc_execute(struct smtpc_request *req, double timeout)
 		req->status = (int) longval;
 		req->reason = "Ok";
 		break;
-	case CURLE_SSL_CACERT:
+#if LIBCURL_VERSION_NUM < 0x073e00
+	case CURLE_SSL_CACERT: /* deprecated in libcurl 7.62.0 */
+#endif
 	case CURLE_PEER_FAILED_VERIFICATION:
 		/* SSL Certificate Error */
 		req->status = -1;


### PR DESCRIPTION
Use CURLE_SSL_CACERT in case value only if libcurl have version < 7.62.0 because in newer version CURLE_PEER_FAILED_VERIFICATION is alias for CURLE_SSL_CACERT as a result we have a broken build