### PR TITLE
Add curl to target_link_libraries

### DIFF
--- a/smtp/CMakeLists.txt
+++ b/smtp/CMakeLists.txt
@@ -4,7 +4,7 @@ endif(APPLE)
 
 # Add C library
 add_library(lib SHARED lib.c smtpc.c)
-target_link_libraries(lib ${MSGPUCK_LIBRARIES})
+target_link_libraries(lib curl ${MSGPUCK_LIBRARIES})
 set_target_properties(lib PROPERTIES PREFIX "" OUTPUT_NAME "lib")
 
 # Install module


### PR DESCRIPTION
The problem was appeared then I try to install this module for tarantool with statically bundled libcurl