### PR TITLE
Check request input params

### DIFF
--- a/smtp/init.lua
+++ b/smtp/init.lua
@@ -151,10 +151,10 @@ curl_mt = {
         --
         request = function(self, url, from, to, body, opts)
             opts = opts or {}
-            to = to or {}
-            if not body or not url or not from then
+            if not body or not url or not from or not (to or opts.cc or opts.bcc) then
                 error('request(url, from, to, body [, options]])')
             end
+            to = to or {}
             local header = ''
             local recipients = {}
             header = 'From: ' .. from .. '\r\n' ..

--- a/smtp/init.lua
+++ b/smtp/init.lua
@@ -151,10 +151,15 @@ curl_mt = {
         --
         request = function(self, url, from, to, body, opts)
             opts = opts or {}
-            if not body or not url or not from or not (to or opts.cc or opts.bcc) then
+            to = to or {}
+            if not body or not url or not from then
                 error('request(url, from, to, body [, options]])')
             end
-            to = to or {}
+            if (not to or not (to and to == {} or #to > 0)) and
+               (not opts.cc or not (opts.cc and opts.cc == {} or #opts.cc > 0)) and
+               (not opts.bcc or not (opts.bcc and opts.bcc == {} or #opts.cc > 0)) then
+                error('No recipients in request')
+            end
             local header = ''
             local recipients = {}
             header = 'From: ' .. from .. '\r\n' ..

--- a/test/smtp.test.lua
+++ b/test/smtp.test.lua
@@ -56,7 +56,7 @@ local server = socket.tcp_server('127.0.0.1', 0, smtp_h)
 local addr = 'smtp://127.0.0.1:' .. server:name().port
 
 test:test("smtp.client", function(test)
-    test:plan(5)
+    test:plan(8)
     local r
     local m
 
@@ -82,6 +82,29 @@ test:test("smtp.client", function(test)
     m = mails:get()
     test:is_deeply(m.rcpt, {'<cc@tarantool.org>'}, 'no rcpt')
 
+    local ok = pcall(function() return
+    client:request(addr, 'sender@tarantool.org',
+                       nil,
+                       'mail.body',
+                       {})
+                    end)
+    test:is(ok, false, 'no any rcpt nil')
+
+    ok = pcall(function() return
+        client:request(addr, 'sender@tarantool.org',
+                           '',
+                           'mail.body',
+                           {})
+                        end)
+    test:is(ok, false, 'no any rcpt blank')
+
+    ok = pcall(function() return
+        client:request(addr, 'sender@tarantool.org',
+                            {},
+                            'mail.body',
+                            {})
+                        end)
+    test:is(ok, false, 'no any rcpt {}')
 end)
 
 os.exit(test:check() == true and 0 or -1)


### PR DESCRIPTION
We have to check input params as early as we can to avoid of execution of any logic and also calling low-level functions if we exactly know that such params will cause an error. 
This little patch checks: "to" and "opts.cc" and "opts.bcc" is not nil, not an empty string or not an empty list. This is not garanties that at least one valid recipient present in params but checks most of possible errors.