### PR TITLE
build: link against Tarantool's libCURL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ set(TARANTOOL_FIND_REQUIRED ON)
 find_package(Tarantool)
 include_directories(${TARANTOOL_INCLUDE_DIRS})
 
+option(TARANTOOL_CURL_REQUIRED "Use Tarantool bundled lubCURL." OFF)
+option(USE_TARANTOOL_CURL "Use Tarantool bundled lubCURL." ON)
+
 # Set CFLAGS
 # set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wextra")

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,6 @@ Maintainer: Roman Tsisyk <roman@tarantool.org>
 Build-Depends: debhelper (>= 9), cdbs,
                cmake (>= 2.8),
                tarantool-dev (>= 1.6.8.0),
-               libmsgpuck-dev (>= 1.0.0),
 # For /usr/bin/prove
                perl (>= 5.10.0),
                libcurl4-openssl-dev | libcurl4-gnutls-dev | libcurl4-nss-dev

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,8 @@
 #!/usr/bin/make -f
 
 DEB_CMAKE_EXTRA_FLAGS := -DCMAKE_INSTALL_LIBDIR=lib/$(DEB_HOST_MULTIARCH) \
-                         -DCMAKE_BUILD_TYPE=RelWithDebInfo
+                         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+                         -DTARANTOOL_CURL_REQUIRED=ON
 DEB_MAKE_CHECK_TARGET := check
 
 include /usr/share/cdbs/1/rules/debhelper.mk

--- a/rpm/tarantool-smtp.spec
+++ b/rpm/tarantool-smtp.spec
@@ -20,7 +20,7 @@ This package provides SMTP client module for Tarantool.
 %setup -q -n %{name}-%{version}
 
 %build
-%cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo
+%cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DTARANTOOL_CURL_REQUIRED=ON
 make %{?_smp_mflags}
 
 %check

--- a/smtp-scm-1.rockspec
+++ b/smtp-scm-1.rockspec
@@ -49,6 +49,7 @@ build = {
     type = 'cmake';
     variables = {
         CMAKE_BUILD_TYPE="RelWithDebInfo";
+        TARANTOOL_CURL_REQUIRED=ON;
         TARANTOOL_DIR="$(TARANTOOL_DIR)";
         TARANTOOL_INSTALL_LIBDIR="$(LIBDIR)";
         TARANTOOL_INSTALL_LUADIR="$(LUADIR)";

--- a/smtp/CMakeLists.txt
+++ b/smtp/CMakeLists.txt
@@ -4,7 +4,7 @@ endif(APPLE)
 
 # Add C library
 add_library(lib SHARED lib.c smtpc.c)
-target_link_libraries(lib curl ${MSGPUCK_LIBRARIES})
+target_link_libraries(lib curl)
 set_target_properties(lib PROPERTIES PREFIX "" OUTPUT_NAME "lib")
 
 # Install module

--- a/smtp/CMakeLists.txt
+++ b/smtp/CMakeLists.txt
@@ -4,7 +4,26 @@ endif(APPLE)
 
 # Add C library
 add_library(lib SHARED lib.c smtpc.c)
-target_link_libraries(lib curl)
+
+find_path(TARANTOOL_CURL_INCLUDE_DIR
+          NAMES curl/curl.h
+          PATH_SUFFIXES tarantool)
+if (TARANTOOL_CURL_INCLUDE_DIR AND USE_TARANTOOL_CURL)
+    message(STATUS "Link against tarantool's bundled lubCURL.")
+    set(CURL_LIBRARIES)
+    set(CURL_INCLUDE_DIRS "${TARANTOOL_CURL_INCLUDE_DIR}")
+elseif (TARANTOOL_CURL_REQUIRED)
+    message(FATAL_ERROR "Your Tarantool version doesn't have bundled lubCURL. "
+            "The minimum required version is 1.10.9 or 2.8.1.")
+else()
+    message(WARNING "Installed tarantool version does not ship lubCURL headers."
+            " Fallback to linking with system lubCURL.")
+    set(CURL_LIBRARIES curl)
+    set(CURL_INCLUDE_DIRS)
+endif()
+target_include_directories(lib PRIVATE ${CURL_INCLUDE_DIRS})
+target_link_libraries(lib PRIVATE ${CURL_LIBRARIES})
+
 set_target_properties(lib PROPERTIES PREFIX "" OUTPUT_NAME "lib")
 
 # Install module


### PR DESCRIPTION
Link against Tarantool's libCURL if it is possible (in the case of
libCURL included as bundled library or static build).

Closes #24

To test it, use Tarantool branches: [2.7](https://github.com/tarantool/tarantool/tree/romanhabibov/curl-smtp) and [1.10](https://github.com/tarantool/tarantool/tree/romanhabibov/curl-smtp_1_10).