### PR TITLE
Fix: subject RFC 822 compat

### DIFF
--- a/test/smtp.test.lua
+++ b/test/smtp.test.lua
@@ -114,16 +114,16 @@ test:test("smtp.client", function(test)
     test:is(boundaries + attachment, 5, 'attach plain')
 
     r = client:request(addr, 'sender@tarantool.org',
-    'receiver@tarantool.org',
-    'mail.body',{
-        attachments = {
-        {
-            body = 'Test message',
-            content_type = 'text/plain',
-            filename = 'text.txt',
-            base64_encode = true,
-        }
-    }})
+                       'receiver@tarantool.org',
+                       'mail.body',{
+                           attachments = {
+                           {
+                               body = 'Test message',
+                               content_type = 'text/plain',
+                               filename = 'text.txt',
+                               base64_encode = true,
+                           }
+                       }})
     m = mails:get()
     boundaries = select(2, string.gsub(m.text, "MULTIPART%-MIXED%-BOUNDARY", ""))
     attachment = select(2, string.gsub(m.text, "VGVzdCBtZXNzYWdl", ""))


### PR DESCRIPTION
According to RFC 822#3.3 subject must contain characters with codes 0-127: https://tools.ietf.org/html/rfc822
For compatibility with legacy mail relays simply base64 encode subject field if char codes >127 is present