### PR TITLE
libcurl: load system libcurl library in runtime

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -20,9 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         tarantool:
-          # gh-29: 2.5.{1,2,3}, 2.6.{1,2} and 2.7.1 are disabled
-          # due to symbol names clash and lack of smtp(s) support
-          # in tarantool's bundled libcurl.
           - release/1.10.7
           - release/1.10.8
           - release/1.10.9
@@ -30,13 +27,13 @@ jobs:
           - release/2.4.1
           - release/2.4.2
           - release/2.4.3
-          # - release/2.5.1
-          # - release/2.5.2
-          # - release/2.5.3
-          # - release/2.6.1
-          # - release/2.6.2
+          - release/2.5.1
+          - release/2.5.2
+          - release/2.5.3
+          - release/2.6.1
+          - release/2.6.2
           - release/2.6.3
-          # - release/2.7.1
+          - release/2.7.1
           - release/2.7.2
           - release/2.8.1
           - live/1.10
@@ -127,13 +124,6 @@ jobs:
           - macos-10.15
           - macos-11.0
         tarantool:
-          # gh-29: 2.5.{1,2,3}, 2.6.{1,2} and 2.7.1 are disabled
-          # due to symbol names clash and lack of smtp(s) support
-          # in tarantool's bundled libcurl.
-          #
-          # Unlike source builds we have there, brew tarantool
-          # installation uses system's libcurl and is not affected
-          # by the problem.
           - brew
           - 1.10.7
           - 1.10.8
@@ -142,13 +132,13 @@ jobs:
           - 2.4.1
           - 2.4.2
           - 2.4.3
-          # - 2.5.1
-          # - 2.5.2
-          # - 2.5.3
-          # - 2.6.1
-          # - 2.6.2
+          - 2.5.1
+          - 2.5.2
+          - 2.5.3
+          - 2.6.1
+          - 2.6.2
           - 2.6.3
-          # - 2.7.1
+          - 2.7.1
           - 2.7.2
           - 2.8.1
           - master

--- a/rpm/tarantool-smtp.spec
+++ b/rpm/tarantool-smtp.spec
@@ -12,6 +12,7 @@ BuildRequires: tarantool-devel >= 1.6.8.0
 BuildRequires: curl-devel
 BuildRequires: /usr/bin/prove
 Requires: tarantool >= 1.6.8.0
+Requires: curl
 
 %description
 This package provides SMTP client module for Tarantool.

--- a/smtp/CMakeLists.txt
+++ b/smtp/CMakeLists.txt
@@ -4,7 +4,94 @@ endif(APPLE)
 
 # Add C library
 add_library(lib SHARED lib.c smtpc.c)
-target_link_libraries(lib curl)
+
+# We MUST NOT add the curl library here.
+#
+# Note: The problem is described from the user perspective in [1].
+# The text below is the long explanation how it was solved.
+#
+# The reason why we must avoid dynamic linking with system's
+# libcurl is composition of several facts.
+#
+# The module uses system's libcurl.so, because libcurl symbols
+# that are exported from tarantool executable are not always
+# suitable for the module.
+#
+# 1. There are tarantool releases that do not export libcurl
+#    symbols at all.
+# 2. There are tarantool releases that export partial list of
+#    libcurl public symbols (due to default visibility and lack
+#    of an explicit export list).
+# 3. There are tarantool releases, which offer libcurl without
+#    smtp(s) support.
+#
+# See the affected tarantool releases list in [2].
+#
+# Anyway, the module calls dlopen() with RTLD_DEEPBIND (see
+# smtpc_init()) for loading system's libcurl.so and everything
+# should be fine? Sadly, no...
+#
+# System's libcurl.so is usually built without
+# -Wl,-Bsymbolic-functions (the exception is Ubuntu -- it
+# surprisingly differs here from Debian) and dynamic relocations
+# are generated for exported libcurl functions that libcurl calls
+# from its code. Those calls are dynamic and an application can
+# retarget them just by exporting the target function from its
+# executable. A user may retarget those calls using LD_PRELOAD.
+# This mechanism aims to provide a way to extend or change a
+# shared library functionality.
+#
+# However at least some of such calls (from libcurl's code to a
+# libcurl's exported function) are internal by its nature and,
+# AFAIU, must land to the same libcurl.so version / build. The
+# example I found is calling of curl_multi_add_handle() from the
+# curl_easy_perform() implementation. It fails for me when
+# system's libcurl.so (7.75.0 with smtp(s) support) processes an
+# smtp request and calls curl_multi_add_handle() from tarantool
+# 2.5.3 (libcurl 7.71.1 without smtp(s) support). The error is
+# CURLE_FAILED_INIT.
+#
+# Back to the main question. What is going on if we'll add curl
+# library to the NEEDED entry of the module's dynamic library
+# (using `ld <...> -lcurl` or so)?
+#
+# Tarantool is loaded and calls require('smtp'), the module's
+# lib.so library starts to load. The dynamic linker find the
+# NEEDED entry with system's libcurl.so and loads it. The
+# libcurl.so library has dynamic relocations and they are resolved
+# to the executable's symbols. The module loads libcurl.so using
+# dlopen() that just increases a reference counter of already
+# loaded library. The resolved dynamic relocations remain resolved
+# to the executable and the RTLD_DEEPBIND flag does not affect
+# them. Due to differences in versions / supported protocols (I
+# don't know a presice reason) curl_easy_perform() from the loaded
+# libcurl.so becomes broken and always returns CURLE_FAILED_INIT.
+#
+# What if we'll not add the curl library here?
+#
+# If we're lucky and system's libcurl.so is not loaded without
+# RTLD_DEEPBIND yet, our dlopen() with RTLD_DEEPBIND will work
+# as expected and all symbols from the library will be resolved
+# to the library itself.
+#
+# Sure, if another module has system's libcurl.so in the NEEDED
+# entry or loads it without RTLD_DEEPBIND and this another module
+# is loaded prior to this one we again in the trouble.
+#
+# There are several facts that more or less mitigate the problem:
+#
+# 1. I don't know any other tarantool's module that uses libcurl
+#    (except built-in http.client, which uses built-in libcurl,
+#    and so irrelevant here).
+# 2. Tarantool offers suitable libcurl implementation since
+#    1.10.10, 2.6.3, 2.7.2, 2.8.1 and in all 2.9+. The module
+#    will use the built-in libcurl when possible (it is not
+#    implemented yet, tracked by gh-24).
+#
+# [1]: https://github.com/tarantool/smtp/issues/29
+# [2]: https://github.com/tarantool/smtp/issues/24
+target_link_libraries(lib ${CMAKE_DL_LIBS})
+
 set_target_properties(lib PROPERTIES PREFIX "" OUTPUT_NAME "lib")
 
 # Install module

--- a/smtp/lib.c
+++ b/smtp/lib.c
@@ -280,6 +280,9 @@ static const struct luaL_Reg Client[] = {
 LUA_API int
 luaopen_smtp_lib(lua_State *L)
 {
+	if (smtpc_init() != 0)
+		return luaT_error(L);
+
 	luaL_newmetatable(L, DRIVER_LUA_UDATA_NAME);
 	lua_pushvalue(L, -1);
 	lua_setfield(L, -2, "__index");

--- a/smtp/smtpc.h
+++ b/smtp/smtpc.h
@@ -35,6 +35,21 @@
 
 #include <curl/curl.h>
 
+/* {{{ Subsystem initialization */
+
+/**
+ * Initialize the subsystem.
+ *
+ * Perform libcurl symbols resolving.
+ *
+ * Return 0 on success. Otherwise return -1 and set an error into
+ * the diagnostics area.
+ */
+int
+smtpc_init(void);
+
+/* Subsystem initialization }}} */
+
 /** {{{ Environment */
 
 typedef void CURLM;


### PR DESCRIPTION
It allows to avoid usage of libcurl functions provided by tarantool executable. Those functions are not usable from the module perspective, because there are tarantool releases, which are bundled with libcurl without smtp(s) support. Another problem is that there are releases that do not enforce exporting of the full list of libcurl symbols, so a linker is free to eliminate them from the executable.

See the list of affected tarantool releases in #24 comments. In short, they are 2.5.{1,2,3}, 2.6{1,2} and 2.7.1.

See details in the commit message.

This pull request also adds a check for protocols supported by libcurl and gives a human readable error message at `require('smtp')` if smtp or smtps is not supported.

Automatic choosing between tarantool's built-in libcurl and system's libcurl is out of scope of this pull request and will be implemented in the scope of #24.

Part of #24.
Fixes #29.