### PR TITLE
libcurl: prefer libcurl from tarantool

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -41,6 +41,20 @@ jobs:
           - live/2.7
           - live/2.8
           - live/2.9
+        # Add an extra check or modify a system environment
+        # on one job.
+        include:
+          # Applicable for: 2.6.3, 2.7.2+, 2.8.1+, 2.9+ (gh-4559).
+          #
+          # Verify that system's libcurl headers are not required.
+          - tarantool: live/2.8
+            dont_install_system_libcurl_header: true
+          # Applicable for: 2.6.3, 2.7.2+, 2.8.1+, 2.9+ (gh-4559).
+          #
+          # Verify that tarantool's libcurl headers are preferred
+          # when the system provides them too.
+          - tarantool: live/2.9
+            break_system_libcurl_header: true
 
     env:
       # Prevent packages like tzdata from asking configuration
@@ -99,6 +113,15 @@ jobs:
 
       - name: Install build dependencies for the module
         run: sudo apt-get install -y libcurl4-openssl-dev
+        if: '!matrix.dont_install_system_libcurl_header'
+
+      - name: Inject an error into system's curl/curl.h
+        run: |
+          # Note: It hardcodes known libcurl headers location on
+          # Ubuntu Focal.
+          CURL_H=/usr/include/x86_64-linux-gnu/curl/curl.h
+          echo '#error Deliberately broken from CI' | sudo tee "${CURL_H}"
+        if: matrix.break_system_libcurl_header
 
       - name: Clone the module
         uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,18 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 # Find Tarantool and Lua dependecies
 set(TARANTOOL_FIND_REQUIRED ON)
 find_package(Tarantool)
+
+# Two directories are added into the header search paths:
+#
+# - ${TARANTOOL_DIR}${PREFIX}/include
+# - ${TARANTOOL_DIR}${PREFIX}/include/tarantool
+#
+# So `#include <curl/curl.h>` will prefer libcurl headers shipped
+# by tarantool packages if exists and will fallback to the system
+# ones otherwise.
+#
+# (`-I <dir>` directories are scanned before system ones as for
+# `#include "foo.h"` as well as for `#include <foo.h>`.)
 include_directories(${TARANTOOL_INCLUDE_DIRS})
 
 # Set CFLAGS

--- a/smtp/CMakeLists.txt
+++ b/smtp/CMakeLists.txt
@@ -2,6 +2,15 @@ if (APPLE)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -undefined suppress -flat_namespace")
 endif(APPLE)
 
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    # man 3 dlsym:
+    #
+    #  | The _GNU_SOURCE feature test macro must be defined in
+    #  | order to obtain the definitions of RTLD_DEFAULT and
+    #  | RTLD_NEXT from <dlfcn.h>.
+    add_definitions("-D_GNU_SOURCE")
+endif()
+
 # Add C library
 add_library(lib SHARED lib.c smtpc.c)
 
@@ -13,9 +22,9 @@ add_library(lib SHARED lib.c smtpc.c)
 # The reason why we must avoid dynamic linking with system's
 # libcurl is composition of several facts.
 #
-# The module uses system's libcurl.so, because libcurl symbols
-# that are exported from tarantool executable are not always
-# suitable for the module.
+# The module uses system's libcurl.so when libcurl symbols that
+# are exported from tarantool executable are not suitable for the
+# module, in particular:
 #
 # 1. There are tarantool releases that do not export libcurl
 #    symbols at all.
@@ -59,7 +68,8 @@ add_library(lib SHARED lib.c smtpc.c)
 # lib.so library starts to load. The dynamic linker find the
 # NEEDED entry with system's libcurl.so and loads it. The
 # libcurl.so library has dynamic relocations and they are resolved
-# to the executable's symbols. The module loads libcurl.so using
+# to the executable's symbols. The module checks executable's
+# symbols and, say, find them unsuitable. It loads libcurl.so using
 # dlopen() that just increases a reference counter of already
 # loaded library. The resolved dynamic relocations remain resolved
 # to the executable and the RTLD_DEEPBIND flag does not affect
@@ -85,8 +95,7 @@ add_library(lib SHARED lib.c smtpc.c)
 #    and so irrelevant here).
 # 2. Tarantool offers suitable libcurl implementation since
 #    1.10.10, 2.6.3, 2.7.2, 2.8.1 and in all 2.9+. The module
-#    will use the built-in libcurl when possible (it is not
-#    implemented yet, tracked by gh-24).
+#    uses the built-in libcurl when possible.
 #
 # [1]: https://github.com/tarantool/smtp/issues/29
 # [2]: https://github.com/tarantool/smtp/issues/24


### PR DESCRIPTION
The change is quite straightforward: attempt to find necessary functions
in tarantool's executable (or libraries it depends on) and verify that
they're suitable for the module. If they're not, issue a warning and try 
to load system's libcurl.

I left the dependency on system's libcurl in the RPM / Deb packages,
because there are tarantool releases on which it is required for loading
of the module.

Maybe it is possible to depend either on a new tarantool release or on
an old tarantool release plus system's libcurl, but I'll leave it as
possible future enhancement.

Building of the module from the rockspec does not require libcurl.so to
be present in the system. It also don't require presence of libcurl
headers in ${PREFIX}/include/curl if they're shipped by tarantool.

Presence of system's libcurl.so is not required to load the module on
recent tarantool releases: 1.10.10, 2.6.3, 2.7.2+, 2.8.1+, 2.9+ (when it
is built with bundled libcurl that is the case for our RPM / Deb 
packages). Tarantool installation on Mac OS from brew is linked with
system's libcurl and the module will use it too.

Aside of this, added a couple of checks into CI to verify that in 
presence of libcurl headers that are shipped by tarantool, system ones 
are not required, and that tarantool's ones are preferred when both are 
available.

Fixes #24