### PR TITLE
Fix build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 
-# Find Tarantool and Lua dependecies
+# Find Tarantool and Lua dependencies
 set(TARANTOOL_FIND_REQUIRED ON)
 find_package(Tarantool)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,6 @@ include_directories(${TARANTOOL_INCLUDE_DIRS})
 # Set CFLAGS
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wextra")
-# Set CXXFLAGS
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra")
 
 # Build module
 add_subdirectory(smtp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(Tarantool)
 include_directories(${TARANTOOL_INCLUDE_DIRS})
 
 # Set CFLAGS
-# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Wall -Wextra")
 # Set CXXFLAGS
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
This patch adds "-std=gnu99" flag to fix following error when user
tries to build on CentOS 7:
```
[ 66%] Building C object smtp/CMakeFiles/lib.dir/smtpc.c.o
/tmp/luarocks_smtp-0.0.5-1-kgB1u4/smtp/smtp/smtpc.c: In function ‘check_libcurl_protocol’:
/tmp/luarocks_smtp-0.0.5-1-kgB1u4/smtp/smtp/smtpc.c:103:2: error: ‘for’ loop initial declarations are only allowed in C99 mode
 for (const char * const *p = info->protocols; *p != NULL; ++p) {
 ^
/tmp/luarocks_smtp-0.0.5-1-kgB1u4/smtp/smtp/smtpc.c:103:2: note: use option -std=c99 or -std=gnu99 to compile your code
gmake[2]: *** [smtp/CMakeFiles/lib.dir/smtpc.c.o] Error 1
gmake[1]: *** [smtp/CMakeFiles/lib.dir/all] Error 2
gmake: *** [all] Error 2

Error: Failed installing dependency: http://rocks.tarantool.org/smtp-0.0.5-1.rockspec - Build error: Failed building.
```

Closes #39