### PR TITLE
Add handing of SMTP server error messages

### DIFF
--- a/smtp/smtpc.h
+++ b/smtp/smtpc.h
@@ -116,6 +116,7 @@ struct smtpc_request {
 	int status;
 	/** Error message. */
 	const char *reason;
+	char *curl_error;
 };
 
 /**


### PR DESCRIPTION
…mtp server or reports meaningless error messages if gets a.e. 5xx error codes.

This patch adds handling of curl errors if smtp server drops connection or doesn't reply correctly on rcpt command.
It also provides test for SMTP error codes 3xx, 4xx, 5xx and unexpected errors handling.

Fixes #13