### PR TITLE
curl: unable to load libcurl.so

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -73,13 +73,15 @@ jobs:
           # uses the libcurl implementation provided by tarantool
           # executable and when the module falls back to the
           # system libcurl.
-          #
-          # TODO: Enable 1.10.7 jobs after resolving gh-44
-          # ('Unable to load libcurl.so'). Don't forget to exclude
-          # distribution versions, which are not supported by
-          # tarantool 1.10.7.
-          # - release/1.10.7
+          - release/1.10.7
           - live/2.9
+        exclude:
+          # Tarantool 1.10.7 release is not supported on
+          # debian:bullseye and fedora:34.
+          - platform: {os: debian, dist: bullseye}
+            tarantool: release/1.10.7
+          - platform: {os: fedora, dist: 34}
+            tarantool: release/1.10.7
 
     env:
       # Prevent packages like tzdata from asking configuration

--- a/smtp/smtpc.c
+++ b/smtp/smtpc.c
@@ -158,9 +158,9 @@ smtpc_init(void)
 
 	const char *libname;
 #ifdef __APPLE__
-	libname = "libcurl.dylib";
+	libname = "libcurl.4.dylib";
 #else
-	libname = "libcurl.so";
+	libname = "libcurl.so.4";
 #endif
 
 	/* Warn a user that we unable to use built-in libcurl. */


### PR DESCRIPTION
The problem appears when the module falls back to the system libcurl
(on relatively old tarantool versions) and when there is no dynamic library
named exactly as 'libcurl.so' (without the version suffix). This situation
usually occurs, when the module is installed from an RPM or Deb package
and the developer libcurl package is not installed.

Fixes #44