### PR TITLE
github-ci: could not find openssl while building

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -198,7 +198,7 @@ jobs:
         if: matrix.tarantool != 'brew' && matrix.tarantool != 'master'
 
       - name: Install tarantool build dependencies
-        run: brew install autoconf automake libtool
+        run: brew install autoconf automake libtool openssl@1.1
         if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
 
       - name: Clone tarantool ${{ env.T_VERSION }}
@@ -223,7 +223,11 @@ jobs:
           # There are tarantool releases on which AppleClang
           # complains about the problem that was fixed later in
           # https://github.com/tarantool/tarantool/commit/7e8688ff8885cc7813d12225e03694eb8886de29
-          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          #
+          # Set OpenSSL root directory for linking tarantool with OpenSSl of version 1.1
+          # This is related to #49. There are too much deprecations which affect the build and tests.
+          # Must be revisited after fixing https://github.com/tarantool/tarantool/issues/6477
+          cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -DOPENSSL_LIBRARIES=/usr/local/opt/openssl@1.1/lib
 
           # {{{ Workaround Mac OS build failure (gh-6076)
           #

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -214,6 +214,13 @@ jobs:
           fetch-depth: 0
         if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
 
+      - name: Patching tarantool for successful build
+        run: |
+          # These steps fix the problem with tarantool build described in
+          # https://github.com/tarantool/tarantool/issues/6576
+          git show 11e87877df9001a4972019328592d79d55d1bb01 | patch -p1
+        if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
+
       - name: Build tarantool ${{ env.T_VERSION }} from sources
         run: |
           mkdir "${T_DESTDIR}"
@@ -224,7 +231,7 @@ jobs:
           # complains about the problem that was fixed later in
           # https://github.com/tarantool/tarantool/commit/7e8688ff8885cc7813d12225e03694eb8886de29
           #
-          # Set OpenSSL root directory for linking tarantool with OpenSSl of version 1.1
+          # Set OpenSSL root directory for linking tarantool with OpenSSL of version 1.1
           # This is related to #49. There are too much deprecations which affect the build and tests.
           # Must be revisited after fixing https://github.com/tarantool/tarantool/issues/6477
           cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1 -DOPENSSL_LIBRARIES=/usr/local/opt/openssl@1.1/lib


### PR DESCRIPTION
OSX workflows use brew for install openssl. Since brew
updated the openssl formula, it is needed to install
openssl@1.1 explicitly for successful build of Tarantool.

After the problem with openssl was solved, I have faced a problem which seems to be related to [#6576](https://github.com/tarantool/tarantool/issues/6576). 
This one seems to be fixed with this [commit](https://github.com/tarantool/tarantool/commit/d83e1901dc885234fe59eb326748c4d71e106c71). As I see, this patch have not reached Tarantool minor versions which are represented in `matrix` for workflow jobs, so all builds of unpatched versions are failed with this problem.

Fixes #49