### PR TITLE
ci: update metadata before installing dependencies

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -78,7 +78,18 @@ jobs:
           nightly-build: ${{ startsWith(matrix.tarantool, 'live/') }}
 
       - name: Install build dependencies for the module
-        run: sudo apt-get install -y libcurl4-openssl-dev
+        run: |
+          # If setup-tarantool action above get tarantool from the
+          # cache, the runner may have old repository metadata.
+          #
+          # We can meet the situation, when the old metadata
+          # contains libcurl4-openssl-dev of version X, but
+          # the mirror has only newer version Y (older ones
+          # are pruned).
+          #
+          # Update the metadata to don't step into the problem.
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev
         if: '!matrix.dont_install_system_libcurl_header'
 
       - name: Inject an error into system's curl/curl.h


### PR DESCRIPTION
It seems we have obsoleted repository metadata on the GitHub hosted
runners and should update it before attempt to install packages.

I got the following error without `apt-get update`:

```
Ign:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4-openssl-dev amd64 7.68.0-1ubuntu2.11
Err:1 http://azure.archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4-openssl-dev amd64 7.68.0-1ubuntu2.11
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.68.0-1ubuntu2.11_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

Check the mirror:

```
$ curl -SsfL http://azure.archive.ubuntu.com/ubuntu/pool/main/c/curl/ \
    | grep 'href=".*\.deb"'                                           \
    | sed 's@.*href="\([^"]\+\)".*@\1@'                               \
    | grep 'libcurl4-openssl-dev_7.68.0.*_amd64.deb'

libcurl4-openssl-dev_7.68.0-1ubuntu2.12_amd64.deb
libcurl4-openssl-dev_7.68.0-1ubuntu2_amd64.deb
```

It has no `7.68.0-1ubuntu2.11` version, but has `7.68.0-1ubuntu2.12`.