### PR TITLE
client: always free the request structure

### DIFF
--- a/smtp/lib.c
+++ b/smtp/lib.c
@@ -188,6 +188,7 @@ luaT_smtpc_request(lua_State *L)
 	lua_pop(L, 1);
 
 	if (smtpc_execute(req, timeout) != 0) {
+		smtpc_request_delete(req);
 		return luaT_error(L);
 	}
 

--- a/smtp/smtpc.c
+++ b/smtp/smtpc.c
@@ -448,7 +448,6 @@ smtpc_execute(struct smtpc_request *req, double timeout)
 		box_error_set(__FILE__, __LINE__, ER_MEMORY_ISSUE,
 			      "Curl internal memory issue");
 		++env->stat.failed_requests;
-		smtpc_request_delete(req);
 		return -1;
 	case CURLE_SEND_ERROR:
 	case CURLE_RECV_ERROR:
@@ -472,7 +471,6 @@ smtpc_execute(struct smtpc_request *req, double timeout)
 		snprintf(error_msg, sizeof(error_msg), "CURL error %i (os errno %li)", req->code, longval);
 		box_error_set(__FILE__, __LINE__, ER_UNKNOWN, error_msg);
 		++env->stat.failed_requests;
-		smtpc_request_delete(req);
 		return -1;
 	}
 	}


### PR DESCRIPTION
`smtpc_execute()` returns `-1` and doesn't free the request structure if
`coio_call()` failed to allocate the coio task structure. I also found
it confusing that `smtpc_execute()` frees the request structure, so
moved it to `luaT_smtpc_request()`, where it is allocated.

See the linked issue for a bit more detailed description.

Fixes #55