### PR TITLE
ci: drop macOS 10.15 from CI

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -121,7 +121,6 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - macos-10.15
           - macos-11.0
         tarantool:
           - brew


### PR DESCRIPTION
This virtual environment is deprecated now. It seems it is the reason why I sometimes see that it is cancelled with 0s execution time.

I'll add macos-12.0 in a separate pull request.

https://github.com/actions/runner-images/issues/5583