### PR TITLE
ci: add macOS 12

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -121,7 +121,8 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - macos-11.0
+          - macos-11
+          - macos-12
         tarantool:
           - brew
           - 1.10.7


### PR DESCRIPTION
https://github.blog/changelog/2022-06-13-github-actions-macos-12-for-github-hosted-runners-is-now-generally-available/

At some point `macos-11.0` label was replaced by `macos-11`, see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on, https://github.com/actions/runner-images/pull/3427, https://github.com/actions/runner-images/pull/3633. Moreover, `macos-12.0` does not work at all, so let's use the similar named `macos-11` and `macos-12` (as current documentation anyway suggests).