### PR TITLE
ci: switch to node16 runtime

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the module
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # fetch-depth is 1 by default and it is okay for
           # building from a tag. However it is convenient to
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
 
       - name: Clone packpack
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: packpack/packpack
           path: packpack
@@ -45,7 +45,7 @@ jobs:
           export DIST=${{ matrix.platform.dist }}
           ./packpack/packpack
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: ${{ format('{0}-{1}', matrix.platform.os, matrix.platform.dist) }}
           path: build
@@ -179,7 +179,7 @@ jobs:
       # }}} Install tarantool
 
       - name: Download the module package
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ format('{0}-{1}', matrix.platform.os, matrix.platform.dist) }}
 
@@ -206,7 +206,7 @@ jobs:
         if: matrix.platform.os == 'debian' || matrix.platform.os == 'ubuntu'
 
       - name: Clone the module
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run tests
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
@@ -20,7 +20,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Create a rockspec for the release.
       - run: printf '%s=%s\n' TAG "${GITHUB_REF##*/}" >> "${GITHUB_ENV}"
@@ -48,7 +48,7 @@ jobs:
       # LuaJIT's FFI and tarantool specific features are okay.
       #
       # [1]: https://github.com/luarocks/luarocks/wiki/Types-of-rocks
-      - uses: tarantool/setup-tarantool@v1
+      - uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: '1.10'
       - run: tarantoolctl rocks pack smtp-${{ env.TAG }}-1.rockspec

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: 'Clone the smtp module'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository_owner }}/smtp
 
       - name: 'Download the tarantool build artifact'
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,7 +72,7 @@ jobs:
           printf '%s=%s\n' T_VERSION "${T_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Install tarantool ${{ matrix.tarantool }}
-        uses: tarantool/setup-tarantool@v1
+        uses: tarantool/setup-tarantool@v2
         with:
           tarantool-version: '${{ env.T_VERSION }}'
           nightly-build: ${{ startsWith(matrix.tarantool, 'live/') }}
@@ -101,7 +101,7 @@ jobs:
         if: matrix.break_system_libcurl_header
 
       - name: Clone the module
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build the module
         run: cmake . && make
@@ -161,7 +161,7 @@ jobs:
         if: matrix.tarantool == 'brew'
 
       - name: Cache built tarantool ${{ env.T_VERSION }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache
         with:
           path: ${{ env.T_DESTDIR }}
@@ -184,7 +184,7 @@ jobs:
         if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
 
       - name: Clone tarantool ${{ env.T_VERSION }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: tarantool/tarantool
           ref: ${{ env.T_VERSION }}
@@ -270,7 +270,7 @@ jobs:
         if: matrix.tarantool != 'brew' && matrix.tarantool != 'master'
 
       - name: Clone the module
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: ${{ env.SRCDIR }}
 


### PR DESCRIPTION
Updated actions to versions with node16 runtime. See the following GitHub's announcements:

* https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/
* https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/