### PR TITLE
api: add hardcoded versioning support

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -3,12 +3,29 @@ name: packaging
 on: [push, pull_request]
 
 jobs:
+  # Run not only on tags, otherwise dependent job will skip.
+  version-check:
+    # Skip pull request job when the source branch is in the same
+    # repository.
+    if: |
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        # We need this step to run only on push with tag.
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'smtp'
+
   build_package:
     # Skip pull request jobs when the source branch is in the same
     # repository.
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
+    needs: version-check
 
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,16 @@ on:
     tags: ['*']
 
 jobs:
+  version-check:
+    # We need this job to run only on push with tag.
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check module version
+        uses: tarantool/actions/check-module-version@master
+        with:
+          module-name: 'smtp'
+
   publish-scm-1:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
@@ -18,6 +28,7 @@ jobs:
 
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: version-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/smtp/CMakeLists.txt
+++ b/smtp/CMakeLists.txt
@@ -104,5 +104,5 @@ target_link_libraries(lib ${CMAKE_DL_LIBS})
 set_target_properties(lib PROPERTIES PREFIX "" OUTPUT_NAME "lib")
 
 # Install module
-install(FILES init.lua DESTINATION ${TARANTOOL_INSTALL_LUADIR}/${PROJECT_NAME}/)
+install(FILES init.lua version.lua DESTINATION ${TARANTOOL_INSTALL_LUADIR}/${PROJECT_NAME}/)
 install(TARGETS lib LIBRARY DESTINATION ${TARANTOOL_INSTALL_LIBDIR}/${PROJECT_NAME}/)

--- a/smtp/init.lua
+++ b/smtp/init.lua
@@ -277,7 +277,11 @@ curl_mt = {
 --
 -- Export
 --
-local this_module = { new = smtp_new, _CURL_VERSION = driver._CURL_VERSION }
+local this_module = {
+    new = smtp_new,
+    _CURL_VERSION = driver._CURL_VERSION,
+    _VERSION = require('smtp.version'),
+}
 
 package.loaded['smtp.client'] = this_module
 return this_module

--- a/smtp/version.lua
+++ b/smtp/version.lua
@@ -1,0 +1,4 @@
+-- Сontains the module version.
+-- Requires manual update in case of release commit.
+
+return '0.0.6'


### PR DESCRIPTION
Add versioning support, now the module api has `_VERSION` hardcoded variable. Is part of the task [1].

1. https://github.com/tarantool/roadmap-internal/issues/204