### PR TITLE
Fix signed integer overflow in statistics

### DIFF
--- a/smtp/lib.c
+++ b/smtp/lib.c
@@ -55,7 +55,7 @@ static inline void
 lua_add_key_u64(lua_State *L, const char *key, uint64_t value)
 {
 	lua_pushstring(L, key);
-	lua_pushinteger(L, value);
+	luaL_pushuint64(L, value);
 	lua_settable(L, -3);
 }
 /* }}}


### PR DESCRIPTION
A cast of the value above 2^63-1 to `int64_t` has implementation defined behavior, see n1256, 6.3.1.3.3. `lua_pushinteger()` accepts `int64_t`, so passing `uint64_t` value may lead to pushing negative (or other incorrect) value.

Let's use Tarantool specific `luaL_pushuint64()` function instead.

This is mostly just to make things in the right way: it is unlikely to see such large values in the statistics in practice.

See all the details in https://github.com/tarantool/tarantool/pull/8464