### PR TITLE
test: fix errno check in the breakconnect test

### DIFF
--- a/test/smtp.test.lua
+++ b/test/smtp.test.lua
@@ -270,9 +270,11 @@ test:test("smtp.client", function(test)
                        'mail.body')
     local expected_reason = 'response reading failed'
     if is_curl_version_ge(7, 86, 0) == true then
-        expected_reason = 'response reading failed (errno: 115)'
+        expected_reason = 'response reading failed (errno: <errno>)'
     end
-    test:is(r.reason, expected_reason, 'unexpected response code')
+    local reason = r.reason:gsub('errno: [0-9]+', 'errno: <errno>')
+    test:is(reason, expected_reason, 'unexpected response code',
+            {original_reason = r.reason})
     test:is(r.status, -1, 'expected code')
 
     r = client:request(addr, 'sender@tarantool.org',
@@ -298,9 +300,11 @@ test:test("smtp.client", function(test)
                        'mail.body')
     local expected_reason = 'response reading failed'
     if is_curl_version_ge(7, 86, 0) == true then
-        expected_reason = 'response reading failed (errno: 115)'
+        expected_reason = 'response reading failed (errno: <errno>)'
     end
-    test:is(r.reason, expected_reason, 'unexpected response code')
+    local reason = r.reason:gsub('errno: [0-9]+', 'errno: <errno>')
+    test:is(reason, expected_reason, 'unexpected response code',
+            {original_reason = r.reason})
     test:is(r.status, -1, 'expected code')
 
 end)


### PR DESCRIPTION
The errno value was hardcoded into the test, but it is different for Linux and Mac OS.

Linux:

```c
$ cc --std=c89 -Wall -Wextra -x c <(echo -e '#include <stdio.h>\n#include<errno.h>\n#include <string.h>\n\nint main() { int x = EINPROGRESS; printf("errno: %d; msg: %s\\n", x, strerror(x)); return 0; }') && ./a.out; rm a.out
errno: 115; msg: Operation now in progress
```

Mac OS:

```c
$ cc --std=c89 -Wall -Wextra -x c <(echo -e '#include <stdio.h>\n#include<errno.h>\n#include <string.h>\n\nint main() { int x = EINPROGRESS; printf("errno: %d; msg: %s\\n", x, strerror(x)); return 0; }') && ./a.out; rm a.out
errno: 36; msg: Operation now in progress
```

As result the test fails on Mac OS on recent tarantool version (where the new libcurl is bundled).

This commit eliminates the check for particular errno value.

Follows up #70 (PR #71)
Fixes #74