### PR TITLE
ci: workaround release rockspec publishing problem

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
     needs: version-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
The problem is described in https://github.com/tarantool/setup-tarantool/issues/36: `tarantoolctl rocks` from tarantool 1.10 doesn't work on Ubuntu Jammy, when it is installed by the setup-tarantool GitHub Action. Let's use Ubuntu Focal as a temporary workaround.