### PR TITLE
ci: bump actions to use ubuntu-24.04

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -10,7 +10,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         # We need this step to run only on push with tag.
@@ -32,18 +32,19 @@ jobs:
       matrix:
         platform:
           - {os: debian, dist: bullseye}
+          - {os: debian, dist: bookworm}
           - {os: ubuntu, dist: focal}
           - {os: ubuntu, dist: jammy}
-          - {os: centos, dist: 7}
+          - {os: ubuntu, dist: noble}
           - {os: centos, dist: 8}
           - {os: fedora, dist: 34}
           - {os: fedora, dist: 35}
           - {os: fedora, dist: 36}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # fetch-depth is 1 by default and it is okay for
           # building from a tag. However it is convenient to
@@ -51,7 +52,7 @@ jobs:
           fetch-depth: 0
 
       - name: Clone packpack
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: packpack/packpack
           path: packpack
@@ -62,7 +63,7 @@ jobs:
           export DIST=${{ matrix.platform.dist }}
           ./packpack/packpack
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ format('{0}-{1}', matrix.platform.os, matrix.platform.dist) }}
           path: build
@@ -82,11 +83,10 @@ jobs:
       matrix:
         platform:
           - {os: debian, dist: bullseye}
-          - {os: ubuntu, dist: focal}
+          - {os: debian, dist: bookworm}
           - {os: ubuntu, dist: jammy}
-          - {os: centos, dist: 7}
+          - {os: ubuntu, dist: noble}
           - {os: centos, dist: 8}
-          - {os: fedora, dist: 34}
           - {os: fedora, dist: 35}
           - {os: fedora, dist: 36}
         tarantool:
@@ -97,15 +97,17 @@ jobs:
           # executable and when the module falls back to the
           # system libcurl.
           - release/1.10.7
-          - release/2.10.0
+          - release/2.11.6
         exclude:
           # Tarantool 1.10.7 release is not supported on
           # debian:bullseye, ubuntu:jammy and fedora:34,35,36.
           - platform: {os: debian, dist: bullseye}
             tarantool: release/1.10.7
+          - platform: {os: debian, dist: bookworm}
+            tarantool: release/1.10.7
           - platform: {os: ubuntu, dist: jammy}
             tarantool: release/1.10.7
-          - platform: {os: fedora, dist: 34}
+          - platform: {os: ubuntu, dist: noble}
             tarantool: release/1.10.7
           - platform: {os: fedora, dist: 35}
             tarantool: release/1.10.7
@@ -118,7 +120,7 @@ jobs:
       # See https://github.com/packpack/packpack/issues/7
       DEBIAN_FRONTEND: noninteractive
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: ${{ format('{0}:{1}', matrix.platform.os, matrix.platform.dist) }}
     steps:
       # {{{ Distibution specific quirks
@@ -196,7 +198,7 @@ jobs:
       # }}} Install tarantool
 
       - name: Download the module package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ format('{0}-{1}', matrix.platform.os, matrix.platform.dist) }}
 
@@ -223,7 +225,7 @@ jobs:
         if: matrix.platform.os == 'debian' || matrix.platform.os == 'ubuntu'
 
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run tests
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
   version-check:
     # We need this job to run only on push with tag.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check module version
         uses: tarantool/actions/check-module-version@master
@@ -18,9 +18,9 @@ jobs:
 
   publish-scm-1:
     if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: tarantool/rocks.tarantool.org/github-action@master
         with:
           auth: ${{ secrets.ROCKS_AUTH }}
@@ -29,9 +29,9 @@ jobs:
   publish-tag:
     if: startsWith(github.ref, 'refs/tags/')
     needs: version-check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Create a rockspec for the release.
       - run: printf '%s=%s\n' TAG "${GITHUB_REF##*/}" >> "${GITHUB_ENV}"
@@ -59,7 +59,7 @@ jobs:
       # LuaJIT's FFI and tarantool specific features are okay.
       #
       # [1]: https://github.com/luarocks/luarocks/wiki/Types-of-rocks
-      - uses: tarantool/setup-tarantool@v2
+      - uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: '1.10'
       - run: tarantoolctl rocks pack smtp-${{ env.TAG }}-1.rockspec

--- a/.github/workflows/reusable_testing.yml
+++ b/.github/workflows/reusable_testing.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Clone the smtp module'
         uses: actions/checkout@v4

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,41 +17,24 @@ jobs:
       fail-fast: false
       matrix:
         tarantool:
-          - release/1.10.7
-          - release/1.10.8
-          - release/1.10.9
-          - release/1.10.10
-          - release/2.4.1
-          - release/2.4.2
-          - release/2.4.3
-          - release/2.5.1
-          - release/2.5.2
-          - release/2.5.3
-          - release/2.6.1
-          - release/2.6.2
-          - release/2.6.3
-          - release/2.7.1
-          - release/2.7.2
-          - release/2.8.1
-          - release/2.10.0
-          - live/1.10
-          - live/2.6
-          - live/2.7
-          - live/2.8
-          - live/2.9
-        # Add an extra check or modify a system environment
+          - release/1.10.14
+          - release/2.11.6
+          - release/3.2.1
+          - release/3.3.0
+          - release/3.3.1
+      # Add an extra check or modify a system environment
         # on one job.
         include:
           # Applicable for: 2.6.3, 2.7.2+, 2.8.1+, 2.9+ (gh-4559).
           #
           # Verify that system's libcurl headers are not required.
-          - tarantool: live/2.8
+          - tarantool: release/3.2.1
             dont_install_system_libcurl_header: true
           # Applicable for: 2.6.3, 2.7.2+, 2.8.1+, 2.9+ (gh-4559).
           #
           # Verify that tarantool's libcurl headers are preferred
           # when the system provides them too.
-          - tarantool: live/2.9
+          - tarantool: release/3.3.0
             break_system_libcurl_header: true
 
     env:
@@ -60,7 +43,7 @@ jobs:
       # See https://github.com/packpack/packpack/issues/7
       DEBIAN_FRONTEND: noninteractive
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Export T_VERSION environment variable
         run: |
@@ -72,7 +55,7 @@ jobs:
           printf '%s=%s\n' T_VERSION "${T_VERSION}" >> "${GITHUB_ENV}"
 
       - name: Install tarantool ${{ matrix.tarantool }}
-        uses: tarantool/setup-tarantool@v2
+        uses: tarantool/setup-tarantool@v3
         with:
           tarantool-version: '${{ env.T_VERSION }}'
           nightly-build: ${{ startsWith(matrix.tarantool, 'live/') }}
@@ -101,7 +84,7 @@ jobs:
         if: matrix.break_system_libcurl_header
 
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build the module
         run: cmake . && make
@@ -121,27 +104,12 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - macos-11
-          - macos-12
+          - macos-13
         tarantool:
           - brew
-          - 1.10.7
-          - 1.10.8
-          - 1.10.9
-          - 1.10.10
-          - 2.4.1
-          - 2.4.2
-          - 2.4.3
-          - 2.5.1
-          - 2.5.2
-          - 2.5.3
-          - 2.6.1
-          - 2.6.2
-          - 2.6.3
-          - 2.7.1
-          - 2.7.2
-          - 2.8.1
-          - 2.10.0
+          - 1.10.15
+          - 2.11.6
+          - 3.3.1
           - master
 
     env:
@@ -161,7 +129,7 @@ jobs:
         if: matrix.tarantool == 'brew'
 
       - name: Cache built tarantool ${{ env.T_VERSION }}
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache
         with:
           path: ${{ env.T_DESTDIR }}
@@ -184,7 +152,7 @@ jobs:
         if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
 
       - name: Clone tarantool ${{ env.T_VERSION }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: tarantool/tarantool
           ref: ${{ env.T_VERSION }}
@@ -195,17 +163,6 @@ jobs:
           # the version list.
           fetch-depth: 0
         if: matrix.tarantool != 'brew' && steps.cache.outputs.cache-hit != 'true'
-
-      - name: Patching tarantool for successful build
-        run: |
-          cd "${T_SRCDIR}"
-          # These steps fix the problem with tarantool build described in
-          # https://github.com/tarantool/tarantool/issues/6576
-          git show 11e87877df9001a4972019328592d79d55d1bb01 | patch -p1 -f
-        if: matrix.tarantool != 'brew' &&
-            matrix.tarantool != 'master' &&
-            matrix.tarantool != '2.10.0' &&
-            steps.cache.outputs.cache-hit != 'true'
 
       - name: Build tarantool ${{ env.T_VERSION }} from sources
         run: |
@@ -270,7 +227,7 @@ jobs:
         if: matrix.tarantool != 'brew' && matrix.tarantool != 'master'
 
       - name: Clone the module
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ${{ env.SRCDIR }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 project(smtp C)
 

--- a/debian/prebuild.sh
+++ b/debian/prebuild.sh
@@ -1,4 +1,4 @@
-curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash
+curl -LsSf https://www.tarantool.io/release/2.11/installer.sh | sudo bash
 
 # Workaround https://github.com/tarantool/installer.sh/issues/10
 printf '%s\n' 'Package: tarantool-dev'             | sudo tee    /etc/apt/preferences.d/tarantool-dev

--- a/rpm/prebuild.sh
+++ b/rpm/prebuild.sh
@@ -1,1 +1,1 @@
-curl -LsSf https://www.tarantool.io/release/1.10/installer.sh | sudo bash
+curl -LsSf https://www.tarantool.io/release/2.11/installer.sh | sudo bash


### PR DESCRIPTION
Bump actions to use ubuntu-24.04 for fixing the following GitHub
warning:

    The Ubuntu 20.04 Actions runner image will begin deprecation
    on 2025-02-01.

Tarantool pre-build version has been increased to 2.11 because
`installer.sh` version 1.10 does not support Ubuntu `noble`.

Update CMake minumum version to prevent warnings about too old
CMake version during build configuring under Ubuntu 22/24.

Remove too old distros and unsupported tarantool versions from tests.

Part of #TNTP-1918